### PR TITLE
support HiveWithKerberos and HiveWithoutKerberos

### DIFF
--- a/src/main/java/org/apache/hadoop/fs/PrestoFileSystemCache.java
+++ b/src/main/java/org/apache/hadoop/fs/PrestoFileSystemCache.java
@@ -77,6 +77,10 @@ public final class PrestoFileSystemCache
     private synchronized FileSystem getInternal(URI uri, Configuration conf, long unique)
             throws IOException
     {
+        synchronized (UserGroupInformation.class) {
+            UserGroupInformation.setConfiguration(conf);
+        }
+
         UserGroupInformation userGroupInformation = UserGroupInformation.getCurrentUser();
         FileSystemKey key = createFileSystemKey(uri, userGroupInformation, unique);
         Set<?> privateCredentials = getPrivateCredentials(userGroupInformation);


### PR DESCRIPTION
@electrum 
This is a new PR about the PR: https://github.com/prestosql/presto/pull/978 .
I really agree with what Kokosing said: having a classloader separation between catalogs. 
Before we implement classloader separation between catalogs,
I think we can fix the bug first by my PR.
Please review, thx !